### PR TITLE
Fix npm security audit errors. Use rollup instead of gobble

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,23 +28,24 @@
     "README.md"
   ],
   "dependencies": {
-    "graceful-fs": "~2.0.1",
-    "minimatch": "~0.2.14",
-    "es6-promise": "^1.0.0"
+    "es6-promise": "^4.2.5",
+    "graceful-fs": "^4.1.15",
+    "minimatch": "^3.0.4"
   },
   "scripts": {
     "test": "mocha test/test.js",
     "pretest": "npm run build",
-    "build": "gobble build -f dist",
+    "build": "rollup -c",
     "prepublish": "npm test"
   },
   "devDependencies": {
-    "console-group": "^0.1.2",
-    "eslint": "^1.6.0",
-    "gobble": "^0.10.2",
-    "gobble-cli": "^0.4.4",
-    "gobble-rollup-babel": "^0.4.0",
-    "mocha": "^2.3.3",
-    "source-map-support": "^0.3.2"
+    "console-group": "^0.3.3",
+    "eslint": "^5.12.1",
+    "mocha": "^5.2.0",
+    "rollup": "^1.1.1",
+    "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-commonjs": "^9.2.0",
+    "rollup-plugin-node-resolve": "^4.0.0",
+    "source-map-support": "^0.5.10"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,27 @@
+import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
+import buble from 'rollup-plugin-buble'
+
+let defaultConfig = [{
+  input: 'src/spelunk.js',
+  plugins: [
+    resolve({
+      extensions: ['.js'],
+      browser: true
+    }),
+    commonjs({
+      include: 'node_modules/**'
+    }),
+    buble()
+  ],
+  output: [
+    {
+      file: './dist/spelunk.js',
+      format: 'cjs'
+    }
+  ]
+}]
+
+export default commandLineArgs => {
+  return defaultConfig
+}


### PR DESCRIPTION
- Fix npm security warnings. Due to minimatch and gobble.
- Upgrade npm packages
- Use rollup over gobble

@Rich-Harris Thanks for an awesome library. Please push a npm release if everything looks ok to you